### PR TITLE
fixed observation noise bug

### DIFF
--- a/GPro/posterior.py
+++ b/GPro/posterior.py
@@ -113,7 +113,7 @@ class Laplace(PosteriorApproximation):
         def z(f, M):
             """Likelihood function of a preference relation."""
             r, c = M[:, 0], M[:, 1]
-            return ((f[r] - f[c]) / np.sqrt(2) * self.s_eval).flatten()
+            return ((f[r] - f[c]) / np.sqrt(2 * self.s_eval)).flatten()
 
         def delta(f, M, K):
             """Root of the Taylor expansion derivative of log P(f|M)
@@ -140,14 +140,13 @@ class Laplace(PosteriorApproximation):
             for i in range(M_uni.shape[0]):
                 m, n = M_uni[i, 0], M_uni[i, 1]
                 z_mn = z(f, M_uni[[i], :])
-                z_nm = -z_mn
                 pdf_z = norm.pdf(z_mn)
                 cdf_z_mn = norm.cdf(z_mn)
-                cdf_z_nm = norm.cdf(z_nm)
                 c_mn = (pdf_z / cdf_z_mn) ** 2 + pdf_z / cdf_z_mn * z_mn
-                c_nm = (pdf_z / cdf_z_nm) ** 2 + pdf_z / cdf_z_nm * z_nm
-                c[m][n] = -(c_mn + c_nm) / 2 * self.s_eval
-                c[n][m] = -(c_mn + c_nm) / 2 * self.s_eval
+                c[m][n] -= c_mn / 2 / self.s_eval
+                c[n][m] -= c_mn / 2 / self.s_eval
+                c[m][m] += c_mn / 2 / self.s_eval
+                c[n][n] += c_mn / 2 / self.s_eval
             # Gradient
             Kf = np.linalg.solve(K, f)
             g = Kf.flatten() - b

--- a/GPro/preference.py
+++ b/GPro/preference.py
@@ -157,7 +157,7 @@ class ProbitPreferenceGP(Kernel, Acquisition):
             check_kernel(X, **self.kernel.get_params())
 
         if self.post_approx is None:  # Use a Laplace approximation
-            self.post_approx = Laplace(s_eval=1e-5, max_iter=1000,
+            self.post_approx = Laplace(s_eval=self.alpha, max_iter=1000,
                                        eta=0.01, tol=1e-5)
         else:
             if not hasattr(self.post_approx, "get_params"):
@@ -332,4 +332,3 @@ class ProbitPreferenceGP(Kernel, Acquisition):
                 x_max = res.x
                 max_acq = -res.fun[0]
         return np.clip(x_max, bounds[:, 0], bounds[:, 1]).reshape(1, d)
-


### PR DESCRIPTION
When declaring the posterior approximation method in `preference.py`, `s_eval` now takes the default value of `alpha`.

When computing the matrix `c` in `posterior.py`, the second-order derivative term is subtracted from the off-diagonal entries and added to the diagonal entries, following [Chu and Ghahramani, 2005](http://mlg.eng.cam.ac.uk/zoubin/papers/icml05chuwei-pl.pdf).