### PR TITLE
Fix various bugs in check_kernel

### DIFF
--- a/GPro/validations.py
+++ b/GPro/validations.py
@@ -158,7 +158,7 @@ def check_kernel(x, **params):
             length_scale supported.')
         elif any(length_scale) <= 0:
             raise ValueError("length_scale values must be positive.")
-        assert x.shape[0] == len(length_scale), \
+        assert x.shape[1] == len(length_scale), \
             "Array length_scale is of inconsistent dimension."
     elif isinstance(length_scale, str):
         raise ValueError("length_scale must be a positive scalar.")

--- a/GPro/validations.py
+++ b/GPro/validations.py
@@ -152,16 +152,16 @@ def check_kernel(x, **params):
     """
 
     length_scale = params['length_scale']
+    if isinstance(length_scale, str):
+        raise ValueError("length_scale must be a positive scalar.")
     if np.iterable(length_scale):
         if np.asarray(length_scale).dtype.kind not in ('f', 'i', 'u'):
             raise TypeError('Only floating-point, signed or unsigned integer,\
             length_scale supported.')
-        elif any(length_scale) <= 0:
+        elif any(length_scale <= 0):
             raise ValueError("length_scale values must be positive.")
         assert x.shape[1] == len(length_scale), \
             "Array length_scale is of inconsistent dimension."
-    elif isinstance(length_scale, str):
-        raise ValueError("length_scale must be a positive scalar.")
 
     if len(params) > 1:
         nu = params['nu']

--- a/tests/test_validations.py
+++ b/tests/test_validations.py
@@ -1,0 +1,35 @@
+import numpy as np
+import pytest
+
+from GPro.validations import check_kernel
+
+
+def test_check_kernel():
+    X = np.array(
+        [
+            [0.1, 0.2, 0.3],
+            [0.4, 0.5, 0.6],
+        ]
+    )
+    assert check_kernel(X, length_scale=1.0) is None
+    assert check_kernel(X, length_scale=np.array([0.3, 0.4, 0.5])) is None
+
+    with pytest.raises(AssertionError):
+        check_kernel(X, length_scale=np.array([0.3, 0.4]))
+    with pytest.raises(ValueError):
+        check_kernel(X, length_scale="1.0")
+    with pytest.raises(TypeError):
+        check_kernel(X, length_scale=np.array(["0.3", "0.4", "0.5"]))
+    with pytest.raises(ValueError):
+        check_kernel(X, length_scale=np.array([0.3, -0.4, 0.5]))
+    with pytest.raises(ValueError):
+        check_kernel(X, length_scale=np.array([0.3, 0.4, 0.0]))
+
+    # Test nu parameter for Matern kernel:
+    assert check_kernel(X, length_scale=1.0, nu=1.5) is None
+    with pytest.raises(ValueError):
+        check_kernel(X, length_scale=1.0, nu=0.0)
+    with pytest.raises(ValueError):
+        check_kernel(X, length_scale=1.0, nu=-1.5)
+    with pytest.raises(ValueError):
+        check_kernel(X, length_scale=1.0, nu="1.5")


### PR DESCRIPTION
I noticed that it was not possible to use the Kernels with multiple length scales, since `check_kernel` was always complaining. It turns out that it was checking if `n_samples == len(length_scale)` instead of `n_features`.
I fixed the bug and when I was writing a test, I discovered other bugs, which I subsequently also fixed.

This pull request will:

- correctly check the length of the `length_scale` array
- correctly check for negative length scales
- correctly check if `length_scale` is a `str`
- add a test `test_check_kernel` which tests all code paths